### PR TITLE
feat/accessible-headings-and-figures

### DIFF
--- a/sites/coding4.gaiama.org/src/components/CodeBlock.js
+++ b/sites/coding4.gaiama.org/src/components/CodeBlock.js
@@ -124,12 +124,14 @@ export const CodeBlock = ({ children, className, highlight, ...props }) => {
                 return (
                   <div
                     key={i}
+                    id={`L${i + 1}`}
                     {...getLineProps({ line, key: i })}
                     sx={{
                       backgroundColor, // NOTE: maybe apply only to <spans>?
                       display: `grid`,
                       gridTemplateColumns: `20px auto`,
                       px: 3,
+                      ':target': { bg: 'codeLineHighlight' },
                     }}
                   >
                     <div


### PR DESCRIPTION
at the moment it'll conflict with other code-blocks though

planned is to add an `id` to every code-block sthg like `figure-1` then prepend this id to the line ids