### PR TITLE
Add support for self-hosted goatcounter

### DIFF
--- a/packages/gatsby-plugin-goatcounter/README.md
+++ b/packages/gatsby-plugin-goatcounter/README.md
@@ -16,7 +16,7 @@ Adds GDPR compliant [GoatCounter Statistics](https://goatcounter.com/) to your G
 
 I plan to add a component to track outbound links like [gatsby-plugin-google-analytics](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics#outboundlink-component)
 
-For now [count.js](https://gc.zgo.at/count.js) (GoatCounter's minimalistic js file) is loaded once from the official CDN.  
+For now [count.js](https://gc.zgo.at/count.js) (GoatCounter's minimalistic js file) is loaded once from the official CDN.
 Eventually it'll be bundled and inlined, want to talk to GoatCounter for this first tho.
 
 ## Install
@@ -38,9 +38,13 @@ module.exports = {
     {
       resolve: `gatsby-plugin-goatcounter`,
       options: {
-        // REQUIRED! https://[my_code].goatcounter.com
+        // Either `code` or `selfHostUrl` is required.
+        // REQUIRED IF USING HOSTED GOATCOUNTER! https://[my_code].goatcounter.com
         code: 'YOUR_GOATCOUNTER_PAGE_CODE',
-        
+
+        // REQUIRED IF USING SELFHOSTED GOATCOUNTER!
+        selfHostUrl: `https://example.com`
+
         // ALL following settings are OPTIONAL
 
         // Avoids sending pageview hits from custom paths
@@ -85,7 +89,7 @@ module.exports = {
 }
 ```
 
-> NOTE: The `referrer` and `urlCleanup` functions will only add to your page size if you explicitly enable them.  
+> NOTE: The `referrer` and `urlCleanup` functions will only add to your page size if you explicitly enable them.
 > This plugin uses `minimatch` for the `exclude` option, which will only be used at build time, so `minimatch` won't be added to your website.
 
 ### Tip: Additional Site to not spam your main analytics for testing purposes
@@ -138,8 +142,8 @@ const Layout = (props) => {
 > `useGoatCounter` returns a noop function, meaning a no-operation function which does nothing, until GoatCounter.js has loaded. The component will then re-render and send the event.
 
 ### Skip own views
-`gatsby-plugin-goatcounter` skips views if the `localStorageKey` by default `skipgc` has been set in localStorage.  
-You have to visit you-url.com/#skipgc (or you defined localStorageKey) once or set it manually to 't'.  
+`gatsby-plugin-goatcounter` skips views if the `localStorageKey` by default `skipgc` has been set in localStorage.
+You have to visit you-url.com/#skipgc (or you defined localStorageKey) once or set it manually to 't'.
 Why 't'? I basically copied the example from GoatCounter settings. Naming things is hard 😅
 
 ## Questions? Anything unclear?

--- a/packages/gatsby-plugin-goatcounter/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-goatcounter/src/gatsby-ssr.tsx
@@ -1,3 +1,4 @@
+// -*- mode: js; js-indent-level: 2; -*-
 import { PluginOptions, GoatCounter } from './index.d';
 import { RenderBodyArgs } from 'gatsby';
 import * as React from 'react';
@@ -23,10 +24,22 @@ export const onRenderBody = (
       excludePaths.push(mm.makeRe(exclude));
     });
   }
-
   const settings: GoatCounter = { no_onload: true };
   if (pluginOptions.allowLocal) settings.allow_local = true;
+  let goatSrc = {
+    script: "https://gc.zgo.at/count.js",
+    data: `https://${pluginOptions.code}.goatcounter.com/count`,
+    img: `https://${pluginOptions.code}.goatcounter.com/count?p=${pathname}`
 
+  };
+
+  if (pluginOptions.selfHostUrl) {
+    goatSrc = {
+      script:  `${pluginOptions.selfHostUrl}/count.js`,
+      data: `${pluginOptions.selfHostUrl}/count`,
+      img: `${pluginOptions.selfHostUrl}/count`
+    };
+  };
   setComponents([
     <script
       key="gatsby-plugin-goatcounter-config"
@@ -46,8 +59,8 @@ export const onRenderBody = (
     <script
       key="gatsby-plugin-goatcounter"
       async
-      data-goatcounter={`https://${pluginOptions.code}.goatcounter.com/count`}
-      src="https://gc.zgo.at/count.js"
+      data-goatcounter={goatSrc.data}
+      src={goatSrc.script}
     />,
   ]);
 
@@ -55,9 +68,9 @@ export const onRenderBody = (
     setPreBodyComponents([
       <noscript key="gatsby-plugin-goatcounter-noscript">
         <img
-          src={`https://${pluginOptions.code}.goatcounter.com/count?p=${pathname}`}
+          src={goatSrc.img}
         />
-      </noscript>,
+        </noscript>,
     ]);
   }
 };

--- a/packages/gatsby-plugin-goatcounter/src/index.d.ts
+++ b/packages/gatsby-plugin-goatcounter/src/index.d.ts
@@ -2,6 +2,7 @@ type PropertyFunction<T> = () => T;
 
 export type PluginOptions = {
   code: '';
+  selfHostUrl: '';
   exclude: string[];
   pageTransitionDelay: number;
   head: boolean;


### PR DESCRIPTION
Adds a `selfHostUrl` attribute to the `pluginOptions`, where a user can specify a selfhosted goatcounter URL. 