### PR TITLE
Update peer dependencies

### DIFF
--- a/packages/gatsby-plugin-goatcounter/package.json
+++ b/packages/gatsby-plugin-goatcounter/package.json
@@ -18,8 +18,8 @@
     "check-types": "tsc"
   },
   "peerDependencies": {
-    "gatsby": "^2.19.23",
-    "react": "^16.13.0"
+    "gatsby": "^2.32.0",
+    "react": "^17.0.0"
   },
   "dependencies": {
     "minimatch": "3.0.4"


### PR DESCRIPTION
Otherwise the installing this alongside the latest version of React throws an error.

No incompatible changes on the React or Gatsby side as far as I can tell.