### PR TITLE
use canonical link as path, if available

### DIFF
--- a/packages/gatsby-plugin-goatcounter/src/gatsby-browser.tsx
+++ b/packages/gatsby-plugin-goatcounter/src/gatsby-browser.tsx
@@ -38,6 +38,8 @@ export const onRouteUpdate = (
   const sendPageView = () => {
     const path =
       window?.GPGC_CleanPath?.() ??
+      // cast to `any` to fix "href does not exist on Element"
+      (window?.document.querySelector('link[rel=canonical]') as any)?.href ??
       location.pathname + location.search + location.hash;
 
     const settings: CountVars = { ...window.goatcounter, path };


### PR DESCRIPTION
The [GoatCounter docs](https://www.goatcounter.com/help/path#using-a-canonical-url-11) note that if a canonical link is provided, then that will be used instead of building the path. 

```html
<link rel="canonical" href="https://example.com/path">
```

This package ignored the canonical link and always sends the querystring and hash. I've added a case to fetch it, if available.

---

This change introduces some potentially odd behavior. On a page with anchor tags that users jump between, we'll send a lot of duplicate pageviews, inflating the count. The way to mitigate this is to compare `location` and `prevLocation` in `onRouteUpdate` and bail if they're the same. I'm happy to add this too, but figured I'd ask first. That behavior should probably be controlled by a setting. 
